### PR TITLE
Fix case of m4 file extensions

### DIFF
--- a/tutorial2-weapons/src/weapon.rs
+++ b/tutorial2-weapons/src/weapon.rs
@@ -17,7 +17,7 @@ impl Weapon {
     pub async fn new(scene: &mut Scene, resource_manager: ResourceManager) -> Self {
         // Yeah, you need only few lines of code to load a model of any complexity.
         let model = resource_manager
-            .request_model("data/models/m4.fbx")
+            .request_model("data/models/m4.FBX")
             .await
             .unwrap()
             .instantiate_geometry(scene);

--- a/tutorial3-bots-ai/src/weapon.rs
+++ b/tutorial3-bots-ai/src/weapon.rs
@@ -17,7 +17,7 @@ impl Weapon {
     pub async fn new(scene: &mut Scene, resource_manager: ResourceManager) -> Self {
         // Yeah, you need only few lines of code to load a model of any complexity.
         let model = resource_manager
-            .request_model("data/models/m4.fbx")
+            .request_model("data/models/m4.FBX")
             .await
             .unwrap()
             .instantiate_geometry(scene);


### PR DESCRIPTION
Currently the loading of the `m4.FBX` file is done with the `"m4.fbx` path, which won't work on case-sensitive systems. This PR renames it
   
(Minor Note: The file extensions are somewhat inconsistent. Like the zombie using lower-case `fbx` in its filename)